### PR TITLE
Refactor variable naming and simplify IP retrieval

### DIFF
--- a/app/ratelimiting.py
+++ b/app/ratelimiting.py
@@ -4,12 +4,11 @@ from django_ratelimit.decorators import ratelimit
 
 
 def get_client_ip(request):
-    x_forwarded_for = request.headers.get("X-Forwarded-For")
-    if x_forwarded_for:
-        ip = x_forwarded_for.split(",")[0]
-    else:
-        ip = request.META.get("REMOTE_ADDR")
-    return ip
+    return (
+        x_forwarded_for.split(",")[0]
+        if (x_forwarded_for := request.headers.get("X-Forwarded-For"))
+        else request.META.get("REMOTE_ADDR")
+    )
 
 
 ip_ratelimit = partial(

--- a/app/renderer.py
+++ b/app/renderer.py
@@ -12,11 +12,11 @@ def render_html(plugin, context):
 
 
 def render_download(plugin, context):
-    type = ""
+    type_of_download = ""
     if plugin.download.name.endswith((".wav", ".ogg", ".mp3", ".aac")):
-        type = "audio"
+        type_of_download = "audio"
     return render_in_context(
-        context, "plugins/download.html", {"plugin": plugin, "type": type}
+        context, "plugins/download.html", {"plugin": plugin, "type": type_of_download}
     )
 
 


### PR DESCRIPTION
The 'render_download' function in 'renderer.py' now uses 'type_of_download' instead of 'type' for clearer comprehension. For 'ratelimiting.py', the process of obtaining client IP has been simplified for better readability and performance. This change uses a shorter syntax with the same functionality.